### PR TITLE
Make DUSB_VPKT_DELAY_ACK optional

### DIFF
--- a/src/dusb/device.js
+++ b/src/dusb/device.js
@@ -66,6 +66,12 @@ module.exports = class Device {
       throw `Expected raw packet type VIRT_DATA_LAST, but got ${raw.type} instead`;
 
     const virtual = b.destructVirtualPacket(raw.data);
+    if ( virtual.type == v.virtualPacketTypes.DUSB_VPKT_DELAY_ACK && virtualType != virtual.type ) {
+      await this._sendAck();
+      const delay = b.bytesToInt(virtual.data);
+      await this.wait(delay / 1000);
+      return await this.expect(virtualType);
+    }
     if ( virtual.type != virtualType )
       throw `Expected virtual packet type ${virtualType}, but got ${virtual.type} instead`;
 

--- a/src/dusb/device.js
+++ b/src/dusb/device.js
@@ -62,21 +62,28 @@ module.exports = class Device {
   // program from the calculator.
   async expect(virtualType) {
     const raw = b.destructRawPacket(await this._receive());
+
     if ( raw.type != v.rawPacketTypes.DUSB_RPKT_VIRT_DATA_LAST )
       throw `Expected raw packet type VIRT_DATA_LAST, but got ${raw.type} instead`;
 
     const virtual = b.destructVirtualPacket(raw.data);
-    if ( virtual.type == v.virtualPacketTypes.DUSB_VPKT_DELAY_ACK && virtualType != virtual.type ) {
+
+    // Did we get what we expected?
+    if ( virtual.type == virtualType ) {
+      await this._sendAck();
+      return virtual;
+    }
+
+    // If not, did we get a delay request?
+    if ( virtual.type == v.virtualPacketTypes.DUSB_VPKT_DELAY_ACK ) {
       await this._sendAck();
       const delay = b.bytesToInt(virtual.data);
       await this.wait(delay / 1000);
-      return await this.expect(virtualType);
+      return this.expect(virtualType);
     }
-    if ( virtual.type != virtualType )
-      throw `Expected virtual packet type ${virtualType}, but got ${virtual.type} instead`;
 
-    await this._sendAck();
-    return virtual;
+    // Otherwise, we have a problem here
+    throw `Expected virtual packet type ${virtualType}, but got ${virtual.type} instead`;
   }
 
   // Halt execution for the given amount of milliseconds

--- a/src/dusb/ti84series.js
+++ b/src/dusb/ti84series.js
@@ -40,9 +40,6 @@ module.exports = class Ti84series {
       type: v.virtualPacketTypes.DUSB_VPKT_EXECUTE,
       data: [0, 0, v.executeCommands.DUSB_EID_KEY, 0, key]
     });
-    await this._d.expect(v.virtualPacketTypes.DUSB_VPKT_DELAY_ACK);
-    // This does not seem strictly necessary:
-    // await this._d.wait(100);
     await this._d.expect(v.virtualPacketTypes.DUSB_VPKT_DATA_ACK);
   }
 
@@ -56,10 +53,6 @@ module.exports = class Ti84series {
         b.intToBytes(v.parameters.DUSB_PID_FREE_FLASH, 2)
       ].flat()
     });
-
-    const delayResponse = await this._d.expect(v.virtualPacketTypes.DUSB_VPKT_DELAY_ACK);
-    const delay = b.bytesToInt(delayResponse.data);
-    await this._d.wait(delay / 1000);
 
     const paramsResponse = await this._d.expect(v.virtualPacketTypes.DUSB_VPKT_PARM_DATA);
     const params = b.destructParameters(paramsResponse.data);


### PR DESCRIPTION
Make DUSB_VPKT_DELAY_ACK optional by moving the logic for handling it to expect().

Fixes https://github.com/Timendus/ticalc.link/issues/4.