### PR TITLE
Fix splitting of large virtual packets

### DIFF
--- a/src/dusb/magic-values.js
+++ b/src/dusb/magic-values.js
@@ -12,7 +12,9 @@ module.exports = {
 
     DUSB_RPKT_VIRT_DATA:       3,
     DUSB_RPKT_VIRT_DATA_LAST:  4,
-    DUSB_RPKT_VIRT_DATA_ACK:   5
+    DUSB_RPKT_VIRT_DATA_ACK:   5,
+
+    HEADER_SIZE:               4 + 1
   },
 
   // Virtual packet types


### PR DESCRIPTION
Virtual packets with a size approximately equal to or larger than the device's raw packet buffer size currently are not being handled properly. The virtual packet header's size is set to the number of bytes in the first raw packet, rather than the total number of bytes in the virtual packet, and the raw packet exceeds the maximum buffer size as the size of the raw packet header is not included.
This PR fixes this by generating the virtual packet first, before splitting it into chunks to be put into raw packets.