### PR TITLE
Fix off-by-one error in file attribute handling

### DIFF
--- a/src/tifiles.js
+++ b/src/tifiles.js
@@ -130,7 +130,7 @@ function entryHeader(bytes, file) {
       attributes: false
     };
   } else if ( ti83p ) {
-    const attributes = b.bytesToInt(bytes.slice(12, 14).reverse());
+    const attributes = b.bytesToInt(bytes.slice(13, 15).reverse());
     return {
       // packetLength + size + type + padded name + attributes + size2
       size: 2 + 2 + 1 + 8 + 2 + 2,


### PR DESCRIPTION
This was causing files to have the wrong version associated with them, which was what was causing errors transferring archived files on the CE.