### PR TITLE
util fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "GPL-3.0-or-later",
   "devDependencies": {
     "jest": "^26.6.3",
+    "util": "^0.12.4",
     "webpack": "^5.52.1",
     "webpack-cli": "^3.3.12"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
 
   resolve: {
     fallback: {
-      util: false
+      util: require.resolve("util/")
     }
   }
 };


### PR DESCRIPTION
We may want to have this fallback, if webpack 5 completely removes the NodeJS require('util') bit unless we have a fallback. Something to test.